### PR TITLE
Adding translatable message for COD payment option during order creation

### DIFF
--- a/ps_cashondelivery.php
+++ b/ps_cashondelivery.php
@@ -97,7 +97,7 @@ class Ps_Cashondelivery extends PaymentModule
 
         $newOption = new PaymentOption();
         $newOption->setModuleName($this->name)
-            ->setCallToActionText($this->trans('Pay by Cash on Delivery', array(), 'Modules.Cashondelivery.Shop'))
+            ->setCallToActionText($this->fetch('module:ps_cashondelivery/views/templates/hook/ps_cashondelivery_header.tpl'))
             ->setAction($this->context->link->getModuleLink($this->name, 'validation', array(), true))
             ->setAdditionalInformation($this->fetch('module:ps_cashondelivery/views/templates/hook/ps_cashondelivery_intro.tpl'));
 

--- a/views/templates/hook/ps_cashondelivery_header.tpl
+++ b/views/templates/hook/ps_cashondelivery_header.tpl
@@ -1,0 +1,1 @@
+{l s='Pay with cash on delivery (COD)' mod='ps_cashondelivery'}


### PR DESCRIPTION
Currently, the COD message option cannot be translated in the Prestashop BO. The commit adds a new file consists of a translatable message which appears in the BO translation page. The PHP file is changed to fetch the new file during the generation of the call action.