### PR TITLE
Fix translation bug

### DIFF
--- a/ps_cashondelivery.php
+++ b/ps_cashondelivery.php
@@ -46,8 +46,8 @@ class Ps_Cashondelivery extends PaymentModule
 
         parent::__construct();
 
-        $this->displayName = $this->trans('Cash on delivery (COD)', array(), 'Modules.Cashondelivery.Admin');
-        $this->description = $this->trans('Accept cash on delivery payments', array(), 'Modules.Cashondelivery.Admin');
+        $this->displayName = $this->l('Cash on delivery (COD)');
+        $this->description = $this->l('Accept cash on delivery payments');
 
         /* For 1.4.3 and less compatibility */
         $updateConfig = array('PS_OS_CHEQUE', 'PS_OS_PAYMENT', 'PS_OS_PREPARATION', 'PS_OS_SHIPPING', 'PS_OS_CANCELED', 'PS_OS_REFUND', 'PS_OS_ERROR', 'PS_OS_OUTOFSTOCK', 'PS_OS_BANKWIRE', 'PS_OS_PAYPAL', 'PS_OS_WS_PAYMENT');


### PR DESCRIPTION
Fix bug with not existing tranlation on prestashop 1.7.0.3
Here problem https://www.prestashop.com/forums/topic/590736-cash-on-delivery-cod-translation/
And I got the same I can`t find where to translate in admin. If you know pleas show screen and how to get there