### PR TITLE
Set module tab to payments_gateways 

### DIFF
--- a/ps_cashondelivery.php
+++ b/ps_cashondelivery.php
@@ -35,6 +35,7 @@ class Ps_Cashondelivery extends PaymentModule
     public function __construct()
     {
         $this->name = 'ps_cashondelivery';
+        $this->tab = 'payments_gateways';
         $this->author = 'PrestaShop';
         $this->version = '1.0.6';
         $this->need_instance = 1;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Without the tab property, the module is not displayed in the dashboard settings
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes {paste the issue here}.
| How to test?      | Open the dashboard settings to see if the module is displayed
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<img width="1037" alt="2021-09-09 at 2 54 PM" src="https://user-images.githubusercontent.com/793712/132699070-1bd112f6-104b-4114-9894-14c362e53d00.png">

