### PR TITLE
Payment visibilty on cart with virutal products

### DIFF
--- a/ps_cashondelivery.php
+++ b/ps_cashondelivery.php
@@ -73,12 +73,21 @@ class Ps_Cashondelivery extends PaymentModule
     {
         $products = $cart->getProducts();
 
+        $only_virtual = true;
+
         if (!empty($products)) {
             foreach ($products as $product) {
                 $pd = ProductDownload::getIdFromIdProduct((int)($product['id_product']));
                 if ($pd and Validate::isUnsignedInt($pd)) {
                     return true;
                 }
+
+                if($product['is_virtual'] == 0){
+                    $only_virtual = false;
+                }
+            }
+            if($only_virtual){
+                return true;
             }
         }
 


### PR DESCRIPTION
Payment option should not be showed when cart contains only virutal products,

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Payment option should not be showed when cart contains only virutal products,
| Type?             | bug fix 
| BC breaks?        | no
| Deprecations?     |  no
| Fixed ticket?     | 
| How to test?      | Add virtual products to cart and go go checkout
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
