### PR TITLE
Fix payment method name

### DIFF
--- a/controllers/front/validation.php
+++ b/controllers/front/validation.php
@@ -66,7 +66,7 @@ class Ps_CashondeliveryValidationModuleFrontController extends ModuleFrontContro
             (int) $this->context->cart->id,
             (int) Configuration::getGlobalValue(Ps_Cashondelivery::CONFIG_OS_CASH_ON_DELIVERY),
             (float) $this->context->cart->getOrderTotal(true, Cart::BOTH),
-            $this->trans('Cash on delivery', [], 'Modules.Cashondelivery.Shop'),
+            $this->module->displayName,
             null,
             [],
             (int) $this->context->currency->id,


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Fix payment method name, `Modules.Cashondelivery.Shop` translation domain does't not contains `Cash on delivery` string ; on previous module [version 1.0.6](https://github.com/PrestaShop/ps_cashondelivery/blob/v1.0.6/controllers/front/validation.php#L57) `$this->module->displayName` was used, so I restore it.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/28674
| How to test?  | Use another language than english and check payment method name on order confirmation page, order confirmation email, my account > order history.
