### PR TITLE
Check if order is paid with module on displayOrderConfirmation

### DIFF
--- a/ps_cashondelivery.php
+++ b/ps_cashondelivery.php
@@ -100,12 +100,12 @@ class Ps_Cashondelivery extends PaymentModule
      */
     public function hookDisplayOrderConfirmation(array $params)
     {
-        if (empty($params['order'])) {
-            return '';
-        }
-
         /** @var Order $order */
         $order = (isset($params['objOrder'])) ? $params['objOrder'] : $params['order'];
+
+        if (!Validate::isLoadedObject($order) || $order->module !== $this->name) {
+            return '';
+        }
 
         $this->context->smarty->assign([
             'shop_name' => $this->context->shop->name,


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Check if order is paid with Cash on delivery module before display content in hook `displayOrderConfirmation`
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/28882
| How to test?  | Install `ps_cashondelivery` module, pay an order using `ps_wirepayment` module, check in `displayOrderConfirmation` there no content related to `ps_cashondelivery`