### PR TITLE
Update ps_cashondelivery.php

### DIFF
--- a/ps_cashondelivery.php
+++ b/ps_cashondelivery.php
@@ -34,7 +34,7 @@ class Ps_Cashondelivery extends PaymentModule
         'paymentOptions',
     ];
 
-    const CONFIG_OS_CASH_ON_DELIVERY = 'PS_OS_COD_VALIDATION';
+    const CONFIG_OS_CASH_ON_DELIVERY = 'PS_OS_PREPARATION';
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
Set default status after order to processing rather than awaiting cash validation

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc. Feel free to add more information below this table.
| Type?         | bug fix / improvement / new feature / refacto / critical
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes PrestaShop/Prestashop#{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
