### PR TITLE
Replace 9.1.x branch with 9.1.4 tag in CI

### DIFF
--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -36,7 +36,7 @@ jobs:
             PS_THEME_FO: 'classic'
           - PS_VERSION: '9.0.3' 
             PS_THEME_FO: 'classic'
-          - PS_VERSION: '9.1.x' 
+          - PS_VERSION: '9.1.4' 
             PS_THEME_FO: 'classic'
           - PS_VERSION: 'nightly' 
             PS_THEME_FO: 'hummingbird'
@@ -106,7 +106,7 @@ jobs:
           - '8.1.6'
           - '8.2.5'
           - '9.0.3'
-          - '9.1.x'
+          - '9.1.4'
           - 'nightly'
     permissions:
       contents: 'read'


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | dev
| Description?  | The `9.1.x` branch of the PrestaShop repository is being frozen and will be deleted soon (`9.1.5` will be the last 9.1 patch release). This PR updates the CI so it relies on the latest available `9.1` tag (`9.1.4`) instead of the `9.1.x` branch, so the CI keeps working after the branch removal.
| Type?         | improvement
| Category?     | CO
| BC breaks?    | no
| Deprecations? | no
| How to test?  | CI checks must be green.